### PR TITLE
Update python_version for 3.13

### DIFF
--- a/awsiam.json
+++ b/awsiam.json
@@ -13,7 +13,7 @@
     "app_version": "2.1.7",
     "utctime_updated": "2022-01-07T21:35:08.000000Z",
     "package_name": "phantom_awsiam",
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "main_module": "awsiam_connector.py",
     "min_phantom_version": "6.2.1",
     "fips_compliant": true,

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * chore(ci): update pre-commit config
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions-3.13`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions-3.13)